### PR TITLE
[Hyun] step-6 구현 : 댓글 작성 및 삭제, soft delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@
 # 끄적끄적
 ### H2 DB 시퀸스 초기화
   - `alter table <테이블명> alter column <컬럼명> restart with 1`
+
+# 배포 URL
+### http://54.180.13.74:8080/

--- a/src/main/java/kr/codesqaud/cafe/controller/ArticleController.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/ArticleController.java
@@ -3,7 +3,9 @@ package kr.codesqaud.cafe.controller;
 import kr.codesqaud.cafe.SessionConstant;
 import kr.codesqaud.cafe.domain.Article;
 import kr.codesqaud.cafe.domain.dto.ArticleWithWriter;
+import kr.codesqaud.cafe.domain.dto.ReplyWithUser;
 import kr.codesqaud.cafe.repository.ArticleRepository;
+import kr.codesqaud.cafe.repository.H2DBReplyRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,11 +23,13 @@ public class ArticleController {
     private static final String UPDATE = "수정";
 
     private final ArticleRepository articleRepository;
+    private final H2DBReplyRepository replyRepository;
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Autowired
-    public ArticleController(ArticleRepository articleRepository) {
+    public ArticleController(ArticleRepository articleRepository, H2DBReplyRepository replyRepository) {
         this.articleRepository = articleRepository;
+        this.replyRepository = replyRepository;
     }
 
     @GetMapping("/")
@@ -52,7 +56,9 @@ public class ArticleController {
     @GetMapping("/articles/{index}")
     public String showDetailedArticle(@PathVariable int index, Model model) {
         ArticleWithWriter article = articleRepository.findById(index);
+        List<ReplyWithUser> replies = replyRepository.findByArticleId(index);
         model.addAttribute("article", article);
+        model.addAttribute("replies", replies);
 
         return "qna/show";
     }

--- a/src/main/java/kr/codesqaud/cafe/controller/ArticleController.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/ArticleController.java
@@ -2,6 +2,7 @@ package kr.codesqaud.cafe.controller;
 
 import kr.codesqaud.cafe.SessionConstant;
 import kr.codesqaud.cafe.domain.Article;
+import kr.codesqaud.cafe.domain.Reply;
 import kr.codesqaud.cafe.domain.dto.ArticleWithWriter;
 import kr.codesqaud.cafe.domain.dto.ReplyWithUser;
 import kr.codesqaud.cafe.repository.ArticleRepository;
@@ -87,6 +88,15 @@ public class ArticleController {
         Article updateArticle = new Article(0, title, contents);
 
         articleRepository.update(index, updateArticle);
+
+        return "redirect:/articles/{index}";
+    }
+
+    @PostMapping("/articles/{index}/replies")
+    public String reply(@PathVariable int index, @RequestParam String contents, HttpSession session) {
+        Reply reply = new Reply(contents, (int) session.getAttribute(SessionConstant.LOGIN_USER_ID), index);
+
+        replyRepository.save(reply);
 
         return "redirect:/articles/{index}";
     }

--- a/src/main/java/kr/codesqaud/cafe/controller/ArticleController.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/ArticleController.java
@@ -2,7 +2,6 @@ package kr.codesqaud.cafe.controller;
 
 import kr.codesqaud.cafe.SessionConstant;
 import kr.codesqaud.cafe.domain.Article;
-import kr.codesqaud.cafe.domain.Reply;
 import kr.codesqaud.cafe.domain.dto.ArticleWithWriter;
 import kr.codesqaud.cafe.domain.dto.ReplyWithUser;
 import kr.codesqaud.cafe.repository.ArticleRepository;
@@ -88,15 +87,6 @@ public class ArticleController {
         Article updateArticle = new Article(0, title, contents);
 
         articleRepository.update(index, updateArticle);
-
-        return "redirect:/articles/{index}";
-    }
-
-    @PostMapping("/articles/{index}/replies")
-    public String reply(@PathVariable int index, @RequestParam String contents, HttpSession session) {
-        Reply reply = new Reply(contents, (int) session.getAttribute(SessionConstant.LOGIN_USER_ID), index);
-
-        replyRepository.save(reply);
 
         return "redirect:/articles/{index}";
     }

--- a/src/main/java/kr/codesqaud/cafe/controller/GlobalExceptionHandler.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/GlobalExceptionHandler.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
-public class ExceptionController {
+public class GlobalExceptionHandler {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/kr/codesqaud/cafe/controller/ReplyController.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/ReplyController.java
@@ -1,0 +1,32 @@
+package kr.codesqaud.cafe.controller;
+
+import kr.codesqaud.cafe.SessionConstant;
+import kr.codesqaud.cafe.domain.Reply;
+import kr.codesqaud.cafe.repository.H2DBReplyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpSession;
+
+@Controller
+public class ReplyController {
+
+    private final H2DBReplyRepository replyRepository;
+
+    @Autowired
+    public ReplyController(H2DBReplyRepository replyRepository) {
+        this.replyRepository = replyRepository;
+    }
+
+    @PostMapping("/articles/{index}/replies")
+    public String reply(@PathVariable int index, @RequestParam String contents, HttpSession session) {
+        Reply reply = new Reply(contents, (int) session.getAttribute(SessionConstant.LOGIN_USER_ID), index);
+
+        replyRepository.save(reply);
+
+        return "redirect:/articles/{index}";
+    }
+}

--- a/src/main/java/kr/codesqaud/cafe/controller/ReplyController.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/ReplyController.java
@@ -2,9 +2,11 @@ package kr.codesqaud.cafe.controller;
 
 import kr.codesqaud.cafe.SessionConstant;
 import kr.codesqaud.cafe.domain.Reply;
+import kr.codesqaud.cafe.domain.dto.ArticleWithWriter;
 import kr.codesqaud.cafe.repository.H2DBReplyRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,4 +31,9 @@ public class ReplyController {
 
         return "redirect:/articles/{index}";
     }
+
+//    @DeleteMapping("/articles/{articleId}/replies/{replyId}")
+//    public String delete(@PathVariable int articleId, @PathVariable int replyId, HttpSession session) {
+//        int userId = (int) session.getAttribute(SessionConstant.LOGIN_USER_ID);
+//    }
 }

--- a/src/main/java/kr/codesqaud/cafe/controller/ReplyController.java
+++ b/src/main/java/kr/codesqaud/cafe/controller/ReplyController.java
@@ -32,8 +32,16 @@ public class ReplyController {
         return "redirect:/articles/{index}";
     }
 
-//    @DeleteMapping("/articles/{articleId}/replies/{replyId}")
-//    public String delete(@PathVariable int articleId, @PathVariable int replyId, HttpSession session) {
-//        int userId = (int) session.getAttribute(SessionConstant.LOGIN_USER_ID);
-//    }
+    @DeleteMapping("/articles/{articleId}/replies/{replyId}")
+    public String delete(@PathVariable int articleId, @PathVariable int replyId, HttpSession session) {
+        Reply reply = replyRepository.findById(replyId);
+        int userId = (int) session.getAttribute(SessionConstant.LOGIN_USER_ID);
+
+        if (userId != reply.getUserId()) {
+            throw new IllegalArgumentException("[ERROR] 자신이 작성하지 않은 게시물은 삭제할 수 없습니다.");
+        }
+
+        replyRepository.delete(replyId);
+        return "redirect:/articles/{articleId}";
+    }
 }

--- a/src/main/java/kr/codesqaud/cafe/domain/Reply.java
+++ b/src/main/java/kr/codesqaud/cafe/domain/Reply.java
@@ -2,23 +2,24 @@ package kr.codesqaud.cafe.domain;
 
 import java.time.LocalDateTime;
 
-public class Article {
+public class Reply {
 
     private int id;
-    private String title;
     private String contents;
     private LocalDateTime createDate;
     private int userId;
+    private int articleId;
 
-    public Article() {
+
+    public Reply() {
         this.createDate = LocalDateTime.now();
     }
 
-    public Article(int userId, String title, String contents) {
-        this.userId = userId;
-        this.title = title;
+    public Reply(String contents, int userId, int articleId) {
         this.contents = contents;
         this.createDate = LocalDateTime.now();
+        this.userId = userId;
+        this.articleId = articleId;
     }
 
     public int getId() {
@@ -27,14 +28,6 @@ public class Article {
 
     public void setId(int id) {
         this.id = id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
     }
 
     public String getContents() {
@@ -49,10 +42,6 @@ public class Article {
         return createDate;
     }
 
-    public void setCreateDate(LocalDateTime createDate) {
-        this.createDate = createDate;
-    }
-
     public int getUserId() {
         return userId;
     }
@@ -61,5 +50,13 @@ public class Article {
         this.userId = userId;
     }
 
+    public int getArticleId() {
+        return articleId;
+    }
 
+    public void setArticleId(int articleId) {
+        this.articleId = articleId;
+    }
 }
+
+

--- a/src/main/java/kr/codesqaud/cafe/domain/dto/ArticleWithWriter.java
+++ b/src/main/java/kr/codesqaud/cafe/domain/dto/ArticleWithWriter.java
@@ -14,7 +14,6 @@ public class ArticleWithWriter {
 
     public ArticleWithWriter() {
         this.createDate = LocalDateTime.now();
-        this.replyCount = 0;
     }
 
     public ArticleWithWriter(int id, String title, String contents, int userId, String writer) {
@@ -25,7 +24,6 @@ public class ArticleWithWriter {
         this.writer = writer;
 
         this.createDate = LocalDateTime.now();
-        this.replyCount = 0;
     }
 
     public int getId() {

--- a/src/main/java/kr/codesqaud/cafe/domain/dto/ReplyWithUser.java
+++ b/src/main/java/kr/codesqaud/cafe/domain/dto/ReplyWithUser.java
@@ -1,0 +1,63 @@
+package kr.codesqaud.cafe.domain.dto;
+
+import java.time.LocalDateTime;
+
+public class ReplyWithUser {
+
+    private int id;
+    private int userId;
+    private String userName;
+    private String contents;
+    private LocalDateTime createDate;
+
+    public ReplyWithUser() {
+    }
+
+    public ReplyWithUser(int id, int userId, String userName, String contents, LocalDateTime createDate) {
+        this.id = id;
+        this.userId = userId;
+        this.userName = userName;
+        this.contents = contents;
+        this.createDate = createDate;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public void setContents(String contents) {
+        this.contents = contents;
+    }
+
+    public LocalDateTime getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(LocalDateTime createDate) {
+        this.createDate = createDate;
+    }
+}

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBArticleRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBArticleRepository.java
@@ -26,8 +26,8 @@ public class H2DBArticleRepository implements ArticleRepository {
 
     @Override
     public void save(Article article) {
-        String sql = "insert into article (title, contents, createDate, user_id) " +
-                "values (:title, :contents, :createDate, :userId)";
+        String sql = "insert into article (title, contents, createDate, deleted, user_id) " +
+                "values (:title, :contents, :createDate, false, :userId)";
 
         SqlParameterSource param = new BeanPropertySqlParameterSource(article);
 
@@ -39,7 +39,7 @@ public class H2DBArticleRepository implements ArticleRepository {
         String sql = "select a.id, a.title, a.contents, a.createDate, a.user_id, " +
                 "(select user_id from users u where u.id=a.user_id) as writer, " +
                 "(select count(*) from reply r where a.id=r.article_id) as replyCount " +
-                "from article a where a.id=:id";
+                "from article a where a.id=:id and a.deleted=false";
 
         try {
             Map<String, Integer> param = Map.of("id", id);
@@ -54,14 +54,15 @@ public class H2DBArticleRepository implements ArticleRepository {
     public List<ArticleWithWriter> findAll() {
         String sql = "select a.id, a.title, a.contents, a.createDate, a.user_id, u.user_id as writer, " +
                 "(select count(*) from reply r where a.id=r.article_id) as replyCount " +
-                "from article a join users u on a.user_id=u.id order by a.id desc";
+                "from article a join users u on a.user_id=u.id " +
+                "where a.deleted=false order by a.id desc";
 
         return template.query(sql, BeanPropertyRowMapper.newInstance(ArticleWithWriter.class));
     }
 
     @Override
     public void delete(int id) {
-        String sql = "delete from article where id=:id";
+        String sql = "update article set deleted=true where id=:id;";
 
         Map<String, Integer> param = Map.of("id", id);
         template.update(sql, param);

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBArticleRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBArticleRepository.java
@@ -37,7 +37,8 @@ public class H2DBArticleRepository implements ArticleRepository {
     @Override
     public ArticleWithWriter findById(int id) {
         String sql = "select a.id, a.title, a.contents, a.createDate, a.user_id, " +
-                "(select user_id from users u where u.id=a.user_id) as writer " +
+                "(select user_id from users u where u.id=a.user_id) as writer, " +
+                "(select count(*) from reply r where a.id=r.article_id) as replyCount " +
                 "from article a where a.id=:id";
 
         try {
@@ -51,7 +52,8 @@ public class H2DBArticleRepository implements ArticleRepository {
 
     @Override
     public List<ArticleWithWriter> findAll() {
-        String sql = "select a.id, a.title, a.contents, a.createDate, a.user_id, u.user_id as writer " +
+        String sql = "select a.id, a.title, a.contents, a.createDate, a.user_id, u.user_id as writer, " +
+                "(select count(*) from reply r where a.id=r.article_id) as replyCount " +
                 "from article a join users u on a.user_id=u.id order by a.id desc";
 
         return template.query(sql, BeanPropertyRowMapper.newInstance(ArticleWithWriter.class));

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
@@ -34,6 +34,14 @@ public class H2DBReplyRepository {
         template.update(sql, param);
     }
 
+    public Reply findById(int id) {
+        String sql = "select id, contents, createDate, user_id, article_id " +
+                "from reply where id=:id";
+        Map<String, Integer> param = Map.of("id", id);
+
+        return template.queryForObject(sql, param, BeanPropertyRowMapper.newInstance(Reply.class));
+    }
+
     public List<ReplyWithUser> findByArticleId(int articleId) {
         String sql = "select r.id, r.user_id, " +
                 "(select u.user_id from users u where r.user_id=u.id) as userName, " +

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
@@ -1,7 +1,10 @@
 package kr.codesqaud.cafe.repository;
 
 import kr.codesqaud.cafe.domain.Reply;
+import kr.codesqaud.cafe.domain.dto.ArticleWithWriter;
 import kr.codesqaud.cafe.domain.dto.ReplyWithUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -10,12 +13,14 @@ import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.util.List;
+import java.util.Map;
 
 @Repository
 public class H2DBReplyRepository {
 
     private final NamedParameterJdbcTemplate template;
 
+    @Autowired
     public H2DBReplyRepository(DataSource dataSource) {
         this.template = new NamedParameterJdbcTemplate(dataSource);
     }
@@ -29,12 +34,14 @@ public class H2DBReplyRepository {
         template.update(sql, param);
     }
 
-    public List<ReplyWithUser> findAll() {
+    public List<ReplyWithUser> findByArticleId(int articleId) {
         String sql = "select r.id, r.user_id, " +
                 "(select u.user_id from users u where r.user_id=u.id) as userName, " +
-                "r.contents, r.createDate " +
-                "from reply r join article a on r.article_id=a.id";
+                "r.contents, r.createDate from reply r " +
+                "where r.article_id=:articleId";
 
-        return template.query(sql, BeanPropertyRowMapper.newInstance(ReplyWithUser.class));
+
+        Map<String, Integer> param = Map.of("articleId", articleId);
+        return template.query(sql, param, BeanPropertyRowMapper.newInstance(ReplyWithUser.class));
     }
 }

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
@@ -52,4 +52,11 @@ public class H2DBReplyRepository {
         Map<String, Integer> param = Map.of("articleId", articleId);
         return template.query(sql, param, BeanPropertyRowMapper.newInstance(ReplyWithUser.class));
     }
+
+    public void delete(int id) {
+        String sql = "delete from reply where id=:id";
+
+        Map<String, Integer> param = Map.of("id", id);
+        template.update(sql, param);
+    }
 }

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
@@ -1,12 +1,15 @@
 package kr.codesqaud.cafe.repository;
 
 import kr.codesqaud.cafe.domain.Reply;
+import kr.codesqaud.cafe.domain.dto.ReplyWithUser;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 
 @Repository
 public class H2DBReplyRepository {
@@ -24,5 +27,14 @@ public class H2DBReplyRepository {
         SqlParameterSource param = new BeanPropertySqlParameterSource(reply);
 
         template.update(sql, param);
+    }
+
+    public List<ReplyWithUser> findAll() {
+        String sql = "select r.id, r.user_id, " +
+                "(select u.user_id from users u where r.user_id=u.id) as userName, " +
+                "r.contents, r.createDate " +
+                "from reply r join article a on r.article_id=a.id";
+
+        return template.query(sql, BeanPropertyRowMapper.newInstance(ReplyWithUser.class));
     }
 }

--- a/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
+++ b/src/main/java/kr/codesqaud/cafe/repository/H2DBReplyRepository.java
@@ -1,0 +1,28 @@
+package kr.codesqaud.cafe.repository;
+
+import kr.codesqaud.cafe.domain.Reply;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class H2DBReplyRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    public H2DBReplyRepository(DataSource dataSource) {
+        this.template = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    public void save(Reply reply) {
+        String sql = "insert into reply (contents, createDate, user_id, article_id) " +
+                "values (:contents, :createDate, :userId, :articleId)";
+
+        SqlParameterSource param = new BeanPropertySqlParameterSource(reply);
+
+        template.update(sql, param);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.datasource.url=jdbc:h2:~/step-3-db
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
+
+server.servlet.session.tracking-modes=cookie

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -27,7 +27,7 @@
                             </div>
                             <div class="reply" title="댓글">
                                 <i class="icon-reply"></i>
-                                <span class="point">8</span>
+                                <span class="point" th:text="*{replyCount}">8</span>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -27,7 +27,7 @@
                             </div>
                             <div class="reply" title="댓글">
                                 <i class="icon-reply"></i>
-                                <span class="point" th:text="*{replyCount}">8</span>
+                                <span class="point">8</span>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -77,7 +77,7 @@
                                           <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>
                                       </li>
                                       <li>
-                                          <form class="delete-answer-form" action="/questions/413/answers/1405" method="POST">
+                                          <form class="delete-answer-form" action="#" th:action="@{/articles/{articleId}/replies/{replyId}(articleId=${article.id}, replyId=${reply.id})}" method="POST">
                                               <input type="hidden" name="_method" value="DELETE">
                                               <button type="submit" class="delete-answer-button">삭제</button>
                                           </form>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -86,11 +86,11 @@
                               </div>
                           </article>
                       </div>
-                      <form class="submit-write">
+                      <form class="submit-write" method="POST" action="#" th:action="@{/articles/{id}/replies(id=${article.id})}">
                           <div class="form-group" style="padding:14px;">
-                              <textarea class="form-control" placeholder="Update your status"></textarea>
+                              <textarea class="form-control" placeholder="Update your status" name="contents"></textarea>
                           </div>
-                          <button class="btn btn-success pull-right" type="button">답변하기</button>
+                          <button class="btn btn-success pull-right" type="button submit">답변하기</button>
                           <div class="clearfix" />
                       </form>
                   </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -54,21 +54,21 @@
               <div class="qna-comment">
                   <div class="qna-comment-slipp">
                       <p class="qna-comment-count"><strong th:text="*{replyCount}">2</strong>개의 의견</p>
-                      <div class="qna-comment-slipp-articles">
+                      <div class="qna-comment-slipp-articles" th:each="reply : ${replies}">
 
-                          <article class="article" id="answer-1405">
+                          <article class="article" id="answer-1405" th:object="${reply}">
                               <div class="article-header">
                                   <div class="article-header-thumb">
                                       <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
                                   </div>
                                   <div class="article-header-text">
-                                      <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                      <a href="#answer-1434" class="article-header-time" title="퍼머링크">
+                                      <a href="#" th:href="@{/users/{id}(id=*{userId})}" class="article-author-name" th:text="*{userName}">자바지기</a>
+                                      <a href="#" class="article-header-time" title="퍼머링크" th:text="${#temporals.format(reply.createDate, 'yyyy-MM-dd')}">
                                           2016-01-12 14:06
                                       </a>
                                   </div>
                               </div>
-                              <div class="article-doc comment-doc">
+                              <div class="article-doc comment-doc" th:text="*{contents}">
                                   <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
                               </div>
                               <div class="article-util">
@@ -85,43 +85,14 @@
                                   </ul>
                               </div>
                           </article>
-                          <article class="article" id="answer-1406">
-                              <div class="article-header">
-                                  <div class="article-header-thumb">
-                                      <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-                                  </div>
-                                  <div class="article-header-text">
-                                      <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                      <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                          2016-01-12 14:06
-                                      </a>
-                                  </div>
-                              </div>
-                              <div class="article-doc comment-doc">
-                                  <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
-                              </div>
-                              <div class="article-util">
-                                  <ul class="article-util-list">
-                                      <li>
-                                          <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>
-                                      </li>
-                                      <li>
-                                          <form class="form-delete" action="#" th:action="@{/users/{id}(id=*{id})}" method="POST">
-                                              <input type="hidden" name="_method" value="DELETE">
-                                              <button type="submit" class="delete-answer-button">삭제</button>
-                                          </form>
-                                      </li>
-                                  </ul>
-                              </div>
-                          </article>
-                          <form class="submit-write">
-                              <div class="form-group" style="padding:14px;">
-                                  <textarea class="form-control" placeholder="Update your status"></textarea>
-                              </div>
-                              <button class="btn btn-success pull-right" type="button">답변하기</button>
-                              <div class="clearfix" />
-                          </form>
                       </div>
+                      <form class="submit-write">
+                          <div class="form-group" style="padding:14px;">
+                              <textarea class="form-control" placeholder="Update your status"></textarea>
+                          </div>
+                          <button class="btn btn-success pull-right" type="button">답변하기</button>
+                          <div class="clearfix" />
+                      </form>
                   </div>
               </div>
           </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -53,7 +53,7 @@
 
               <div class="qna-comment">
                   <div class="qna-comment-slipp">
-                      <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                      <p class="qna-comment-count"><strong th:text="*{replyCount}">2</strong>개의 의견</p>
                       <div class="qna-comment-slipp-articles">
 
                           <article class="article" id="answer-1405">

--- a/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
+++ b/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
@@ -1,0 +1,59 @@
+package kr.codesqaud.cafe.repository;
+
+import kr.codesqaud.cafe.domain.Article;
+import kr.codesqaud.cafe.domain.Reply;
+import kr.codesqaud.cafe.domain.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class H2DBReplyRepositoryTest {
+
+    private DataSource dataSource;
+    private H2DBUserRepository userRepository;
+    private H2DBArticleRepository articleRepository;
+    private H2DBReplyRepository replyRepository;
+
+    @BeforeEach
+    void init() {
+        dataSource = new DriverManagerDataSource("jdbc:h2:mem:test", "sa", "");
+        userRepository = new H2DBUserRepository(dataSource);
+        articleRepository = new H2DBArticleRepository(dataSource);
+        replyRepository = new H2DBReplyRepository(dataSource);
+
+        userRepository.save(new User("Hyun", "1234", "황현", "ghkdgus29@naver.com"));
+        userRepository.save(new User("Yoon", "1234", "황윤", "ghkddbs28@naver.com"));
+
+        articleRepository.save(new Article(1, "실화냐?", "미안하다 이거 보여주려고 어그로 끌었다."));
+    }
+
+    @AfterEach
+    void clear() {
+        JdbcTemplate template = new JdbcTemplate(dataSource);
+
+        String sql = "delete from reply;" +
+                "alter table reply alter column id restart with 1;" +
+                "delete from article;" +
+                "alter table article alter column id restart with 1;" +
+                "delete from users;" +
+                "alter table users alter column id restart with 1;";
+
+        template.update(sql);
+    }
+
+    @Test
+    @DisplayName("댓글이 제대로 저장된다.")
+    void save() {
+        Reply reply = new Reply("진짜임?", 2, 1);
+        replyRepository.save(reply);
+    }
+}

--- a/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
+++ b/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
@@ -61,7 +61,7 @@ class H2DBReplyRepositoryTest {
         Reply reply = new Reply("진짜임?", 2, 1);
         replyRepository.save(reply);
 
-        List<ReplyWithUser> replies = replyRepository.findAll();
+        List<ReplyWithUser> replies = replyRepository.findByArticleId(1);
 
         assertThat(replies.size()).isEqualTo(1);
         ReplyWithUser replyWithUser = replies.get(0);
@@ -79,7 +79,7 @@ class H2DBReplyRepositoryTest {
         replyRepository.save(reply1);
         replyRepository.save(reply2);
 
-        List<ReplyWithUser> replies = replyRepository.findAll();
+        List<ReplyWithUser> replies = replyRepository.findByArticleId(1);
 
         assertThat(replies.size()).isEqualTo(2);
         assertThat(replies.get(0).getUserName()).isEqualTo("Yoon");

--- a/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
+++ b/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
@@ -3,6 +3,8 @@ package kr.codesqaud.cafe.repository;
 import kr.codesqaud.cafe.domain.Article;
 import kr.codesqaud.cafe.domain.Reply;
 import kr.codesqaud.cafe.domain.User;
+import kr.codesqaud.cafe.domain.dto.ReplyWithUser;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +15,9 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 import javax.sql.DataSource;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -55,5 +60,29 @@ class H2DBReplyRepositoryTest {
     void save() {
         Reply reply = new Reply("진짜임?", 2, 1);
         replyRepository.save(reply);
+
+        List<ReplyWithUser> replies = replyRepository.findAll();
+
+        assertThat(replies.size()).isEqualTo(1);
+        ReplyWithUser replyWithUser = replies.get(0);
+
+        assertThat(replyWithUser.getUserName()).isEqualTo("Yoon");
+        assertThat(replyWithUser.getContents()).isEqualTo("진짜임?");
+    }
+
+    @Test
+    @DisplayName("댓글들을 모두 가져올 수 있다.")
+    void findAll() {
+        Reply reply1 = new Reply("진짜임?", 2, 1);
+        Reply reply2 = new Reply("가짜임ㅋㅋ", 1, 1);
+
+        replyRepository.save(reply1);
+        replyRepository.save(reply2);
+
+        List<ReplyWithUser> replies = replyRepository.findAll();
+
+        assertThat(replies.size()).isEqualTo(2);
+        assertThat(replies.get(0).getUserName()).isEqualTo("Yoon");
+        assertThat(replies.get(1).getUserName()).isEqualTo("Hyun");
     }
 }

--- a/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
+++ b/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
@@ -85,4 +85,19 @@ class H2DBReplyRepositoryTest {
         assertThat(replies.get(0).getUserName()).isEqualTo("Yoon");
         assertThat(replies.get(1).getUserName()).isEqualTo("Hyun");
     }
+
+    @Test
+    @DisplayName("댓글 id를 통해 특정 댓글 검색이 가능하다.")
+    void findById() {
+        Reply reply1 = new Reply("진짜임?", 2, 1);
+        Reply reply2 = new Reply("가짜임ㅋㅋ", 1, 1);
+
+        replyRepository.save(reply1);
+        replyRepository.save(reply2);
+
+        Reply findReply = replyRepository.findById(1);
+
+        assertThat(findReply.getUserId()).isEqualTo(2);
+        assertThat(findReply.getContents()).isEqualTo("진짜임?");
+    }
 }

--- a/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
+++ b/src/test/java/kr/codesqaud/cafe/repository/H2DBReplyRepositoryTest.java
@@ -100,4 +100,18 @@ class H2DBReplyRepositoryTest {
         assertThat(findReply.getUserId()).isEqualTo(2);
         assertThat(findReply.getContents()).isEqualTo("진짜임?");
     }
+
+    @Test
+    @DisplayName("댓글 id를 통해 특정 댓글 삭제가 가능하다.")
+    void delete() {
+        Reply reply1 = new Reply("진짜임?", 2, 1);
+        Reply reply2 = new Reply("가짜임ㅋㅋ", 1, 1);
+
+        replyRepository.save(reply1);
+        replyRepository.save(reply2);
+
+        replyRepository.delete(1);
+
+        assertThat(replyRepository.findByArticleId(1).size()).isEqualTo(1);
+    }
 }

--- a/src/test/resources/test-schema.sql
+++ b/src/test/resources/test-schema.sql
@@ -15,4 +15,15 @@ create table article
     createDate timestamp,
     user_id    int,
     foreign key (user_id) references users (id)
-)
+);
+
+create table reply
+(
+    id         int         primary key auto_increment,
+    contents   varchar(50) not null,
+    createDate timestamp,
+    user_id    int,
+    article_id int,
+    foreign key (user_id) references users (id),
+    foreign key (article_id) references article (id)
+);

--- a/src/test/resources/test-schema.sql
+++ b/src/test/resources/test-schema.sql
@@ -13,6 +13,7 @@ create table article
     title      varchar(30) not null,
     contents   varchar(50) not null,
     createDate timestamp,
+    deleted    boolean,
     user_id    int,
     foreign key (user_id) references users (id)
 );


### PR DESCRIPTION
step-6 요구사항인 댓글 작성 및 삭제, 게시글의 soft delete 를 구현하였습니다.

댓글들을 저장하는 Reply 테이블을 만들고 댓글이 user_id 와 article_id 를 FK 로 가지도록 하였습니다. 
이를 통해 댓글을 작성한 회원과 댓글이 달려있는 게시물을 판별할 수 있도록 하였습니다.

이때 도메인 테이블은 연관관계를 맺는 다른 테이블의 PK 만을 FK 로 가져야 합니다.
그러나 뷰에 뿌려지는 정보들은 다른 테이블의 PK값뿐만 아니라 다른 테이블들의 추가적인 값들이 필요했습니다. 
그래서 join 이나 nested query 가 필요했고, 이를 담아 뷰에 전달하기 위한 전용 DTO 를 만들었습니다.

미션을 진행하면서 고민했던점이 3가지 있습니다.

1. Repository 단에서 DTO 객체에 의존하게 되는데 이게 올바른 방향인지 고민했습니다.
Service 단에서 DTO 객체를 생성하고 여러개의 리포지토리에 의존하는 것이 좋을지, 아니면 저의 구조처럼 Repository 단에서 DTO 객체에 의존하는게 나을지 고민했습니다.
후자의 경우가 코드양은 더 적었지만 DTO 객체와 Repository의 변경주기가 다르다는 생각이 들어 계속 고민했습니다.


2. DB의 join 연산이 비싼 연산이라고 말씀하셔서 최대한 nested query를 사용하는 쪽으로 쿼리를 작성하였습니다. 
아무래도 nested query를 사용하면 쿼리가 길어져 가독성이 떨어지는 느낌이 있는데 join 연산과 nested query 의 성능차이가 유의미한지 궁금했습니다.


3.  게시글을 삭제한 후, 뒤로가기를 누르게 되면 캐시에 의해 삭제한 게시글이 다시 살아나는 현상이 있었습니다.
이를 방지하기 위해 `CacheInvalidateInterceptor` 를 만들어 모든 URL 접근에 대해 캐시무효화를 하도록 하였습니다.
제 생각에 이 방법은 좋은 방법은 아니라고 생각되어 어떤 방식으로 뒤로가기의 문제 발생을 막을 수 있을지 고민중입니다.


서비스와 리포지토리단에서의 테스트코드들은 꼼꼼하게 작성하였지만 컨트롤러 단에서의 테스트는 하나도 작성하지 않았습니다.
그래서 컨트롤러단의 코드작성이 제대로 이루어졌는지 확인하기 위해 불편하게 웹을 띄우고 일일히 눌러보았습니다.
컨트롤러 테스트는 네트워크를 이용하기 때문에 어렵고 무섭다는 생각이 있어 계속 미뤄왔었는데, 같은 조의 포로와 이린이 꼼꼼하게 컨트롤러 테스트를 작성한 것을 보고 반성하였습니다.
남은 미션개수가 많지 않으니 동료들의 코드를 보면서 컨트롤러 테스트를 학습하는 것이 이번주의 목표입니다.
